### PR TITLE
add concourse-bosh-release

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -171,9 +171,12 @@
   categories: [cf-buildpack]
 
 # CI
-- url: https://github.com/concourse/concourse
+- url: https://github.com/concourse/concourse-bosh-release
   categories: [ci, homepage]
   homepage: true
+  min_version: 0.11
+- url: https://github.com/concourse/concourse
+  categories: [ci]
   min_version: 0.11
 
 # Testing


### PR DESCRIPTION
kept the original concourse/concourse there to give folks time to transition

not sure if that'll actually keep working, though, since we'll soon replace concourse/concourse with a non-bosh-release repo (though the bosh release will remain in the old commits in the git history)